### PR TITLE
Deprecate v1 endpoint for fetching zone

### DIFF
--- a/maas-pro.md
+++ b/maas-pro.md
@@ -1086,7 +1086,8 @@ curl https://partners.voiapp.io/v1/vehicles/id/12345678-1337-abcd-1234-1234abcd0
 
 # Zone
 
-## Get zone areas
+## ~~Get zone areas v1~~ (deprecated - please use [the v2 endpoint](#get-zone-areas-v2) below)
+<aside class="warning">This endpoint has been deprecated and will be removed by 2023-12-31 !</aside>
 
 > The zones response model.
 


### PR DESCRIPTION
We added a new area type "free floating". This would BC-break the v1 endpoint. So we created a new endpoint that supports it. In the old endpoint, we just convert them to parking-spots, which is not 100% correct behavior. So we need to nudge our partners to stop using the old endpoint and start using the new one. 

https://voidev.atlassian.net/browse/RID-25